### PR TITLE
✨ Catch exit code for expired token 

### DIFF
--- a/CheckStatus.sh
+++ b/CheckStatus.sh
@@ -12,7 +12,7 @@ function check_status() {
         
     echo "RESPONSE=${RESPONSE}"
     STATUS=$(echo "${RESPONSE}" | jq -r --arg runnerName "${RUNNER_NAME}" \
-    '.runners | map(select(.name == $runnerName)) | .[0].status // "UNKNOWN"' 2>&1)
+    '.runners | map(select(.name == $runnerName)) | .[0].status || "UNKNOWN"' 2>&1)
     # STATUS=$(echo "${RESPONSE}" | jq ".runners[] | select(.name == \"${RUNNER_NAME}\") | .status" 2>&1)
     echo "STATUS=${STATUS}"
     if [ $? -ne 0 ]; then

--- a/CheckStatus.sh
+++ b/CheckStatus.sh
@@ -11,7 +11,9 @@ function check_status() {
         "https://api.github.com/orgs/${ORG_NAME}/actions/runners")
         
     echo "RESPONSE=${RESPONSE}"
-    STATUS=$(echo "${RESPONSE}" | jq ".runners[] | select(.name == \"${RUNNER_NAME}\") | .status" 2>&1)
+    STATUS=$(echo "${RESPONSE}" | jq -r --arg runnerName "${RUNNER_NAME}" \
+    '.runners | map(select(.name == $runnerName)) | .[0].status // "UNKNOWN"' 2>&1)
+    # STATUS=$(echo "${RESPONSE}" | jq ".runners[] | select(.name == \"${RUNNER_NAME}\") | .status" 2>&1)
     echo "STATUS=${STATUS}"
     if [ $? -ne 0 ]; then
         ERRORS+=("${STATUS}")

--- a/CheckStatus.sh
+++ b/CheckStatus.sh
@@ -11,6 +11,7 @@ function check_status() {
         "https://api.github.com/orgs/${ORG_NAME}/actions/runners")
 
     STATUS=$(echo "${RESPONSE}" | jq ".runners[] | select(.name == \"${RUNNER_NAME}\") | .status" 2>&1)
+    echo ${STATUS}
     if [ $? -ne 0 ]; then
         ERRORS+=("${STATUS}")
     else

--- a/CheckStatus.sh
+++ b/CheckStatus.sh
@@ -12,7 +12,8 @@ function check_status(){
     RUNNERS=$(echo "${RESPONSE}" | jq -r '.runners')
     echo "RUNNERS=${RUNNERS}"
     if [ "${RUNNERS}" = "null" ]; then
-        ERRORS+=("No runners found in the response.")
+        echo "Problem with the token"
+        exit 1
         return
     fi
     

--- a/CheckStatus.sh
+++ b/CheckStatus.sh
@@ -9,9 +9,10 @@ function check_status() {
         -H "Authorization: Bearer ${GITHUB_ADMIN_TOKEN}" \
         -H "X-GitHub-Api-Version: ${GITHUB_API_VERSION}" \
         "https://api.github.com/orgs/${ORG_NAME}/actions/runners")
-
+        
+    echo "RESPONSE=${RESPONSE}"
     STATUS=$(echo "${RESPONSE}" | jq ".runners[] | select(.name == \"${RUNNER_NAME}\") | .status" 2>&1)
-    echo ${STATUS}
+    echo "STATUS=${STATUS}"
     if [ $? -ne 0 ]; then
         ERRORS+=("${STATUS}")
     else

--- a/CheckStatus.sh
+++ b/CheckStatus.sh
@@ -5,7 +5,7 @@ function check_status(){
     RUNNER_NAME=$1
     RESPONSE=$(curl -L \
         -H "Accept: application/vnd.github+json" \
-        -H "Authorization: Bearer ${GITHUB_ADMIN_TOKEN}" \
+        -H "Authorization: Bearer ${GITHUB_RUNNER_TOKEN}" \
         -H "X-GitHub-Api-Version: ${GITHUB_API_VERSION}" \
         https://api.github.com/orgs/${ORG_NAME}/actions/runners)
  

--- a/CheckStatus.sh
+++ b/CheckStatus.sh
@@ -1,28 +1,28 @@
 #!/bin/bash
 STATUSES=()
+ERRORS=()
 
-function check_status(){
+function check_status() {
     RUNNER_NAME=$1
     RESPONSE=$(curl -L \
         -H "Accept: application/vnd.github+json" \
         -H "Authorization: Bearer ${GITHUB_ADMIN_TOKEN}" \
         -H "X-GitHub-Api-Version: ${GITHUB_API_VERSION}" \
-        https://api.github.com/orgs/${ORG_NAME}/actions/runners; STATUS1=$?)
-    
-    if [[ $STATUS1 == 0 ]]
-    then 
-        exit $STATUS1  
-    fi   
+        "https://api.github.com/orgs/${ORG_NAME}/actions/runners")
 
-    STATUS=$(echo "${RESPONSE}" | jq ".runners[] | select(.name == \"${RUNNER_NAME}\") | .status")
-    STATUSES+=(${STATUS})
+    STATUS=$(echo "${RESPONSE}" | jq ".runners[] | select(.name == \"${RUNNER_NAME}\") | .status" 2>&1)
+    if [ $? -ne 0 ]; then
+        ERRORS+=("${STATUS}")
+    else
+        STATUSES+=("${STATUS}")
+    fi
 }
 
-runners=( ${RUNNER_NAMES} )
-for runner in "${runners[@]}"
-do
-check_status "${runner}"
-done 
+runners=(${RUNNER_NAMES})
+for runner in "${runners[@]}"; do
+    check_status "${runner}"
+done
 
 # These outputs are used in other steps/jobs via action.yml
 echo "::set-output name=status::${STATUSES[@]}"
+echo "::set-output name=errors::${ERRORS[@]}"

--- a/CheckStatus.sh
+++ b/CheckStatus.sh
@@ -7,7 +7,12 @@ function check_status(){
         -H "Accept: application/vnd.github+json" \
         -H "Authorization: Bearer ${GITHUB_ADMIN_TOKEN}" \
         -H "X-GitHub-Api-Version: ${GITHUB_API_VERSION}" \
-        https://api.github.com/orgs/${ORG_NAME}/actions/runners)
+        https://api.github.com/orgs/${ORG_NAME}/actions/runners; STATUS1=$?)
+    
+    if [[ $STATUS1 == 0 ]]
+    then 
+        exit $STATUS1  
+    fi   
 
     STATUS=$(echo "${RESPONSE}" | jq ".runners[] | select(.name == \"${RUNNER_NAME}\") | .status")
     STATUSES+=(${STATUS})

--- a/CheckStatus.sh
+++ b/CheckStatus.sh
@@ -10,6 +10,7 @@ function check_status(){
         https://api.github.com/orgs/${ORG_NAME}/actions/runners)
         
     RUNNERS=$(echo "${RESPONSE}" | jq -r '.runners')
+    echo "RUNNERS=${RUNNERS}"
     if [ "${RUNNERS}" = "null" ]; then
         ERRORS+=("No runners found in the response.")
         return

--- a/CheckStatus.sh
+++ b/CheckStatus.sh
@@ -1,32 +1,29 @@
 #!/bin/bash
 STATUSES=()
-ERRORS=()
 
-function check_status() {
+function check_status(){
     RUNNER_NAME=$1
     RESPONSE=$(curl -L \
         -H "Accept: application/vnd.github+json" \
         -H "Authorization: Bearer ${GITHUB_ADMIN_TOKEN}" \
         -H "X-GitHub-Api-Version: ${GITHUB_API_VERSION}" \
-        "https://api.github.com/orgs/${ORG_NAME}/actions/runners")
+        https://api.github.com/orgs/${ORG_NAME}/actions/runners)
         
-    echo "RESPONSE=${RESPONSE}"
-    STATUS=$(echo "${RESPONSE}" | jq -r --arg runnerName "${RUNNER_NAME}" \
-    '.runners | map(select(.name == $runnerName)) | .[0].status || "UNKNOWN"' 2>&1)
-    # STATUS=$(echo "${RESPONSE}" | jq ".runners[] | select(.name == \"${RUNNER_NAME}\") | .status" 2>&1)
-    echo "STATUS=${STATUS}"
-    if [ $? -ne 0 ]; then
-        ERRORS+=("${STATUS}")
-    else
-        STATUSES+=("${STATUS}")
+    RUNNERS=$(echo "${RESPONSE}" | jq -r '.runners')
+    if [ "${RUNNERS}" = "null" ]; then
+        ERRORS+=("No runners found in the response.")
+        return
     fi
+    
+    STATUS=$(echo "${RESPONSE}" | jq ".runners[] | select(.name == \"${RUNNER_NAME}\") | .status")
+    STATUSES+=(${STATUS})
 }
 
-runners=(${RUNNER_NAMES})
-for runner in "${runners[@]}"; do
-    check_status "${runner}"
-done
+runners=( ${RUNNER_NAMES} )
+for runner in "${runners[@]}"
+do
+check_status "${runner}"
+done 
 
 # These outputs are used in other steps/jobs via action.yml
 echo "::set-output name=status::${STATUSES[@]}"
-echo "::set-output name=errors::${ERRORS[@]}"

--- a/CheckStatus.sh
+++ b/CheckStatus.sh
@@ -10,7 +10,6 @@ function check_status(){
         https://api.github.com/orgs/${ORG_NAME}/actions/runners)
         
     RUNNERS=$(echo "${RESPONSE}" | jq -r '.runners')
-    echo "RUNNERS=${RUNNERS}"
     if [ "${RUNNERS}" = "null" ]; then
         echo "Problem with the token"
         exit 1

--- a/CheckStatus.sh
+++ b/CheckStatus.sh
@@ -8,14 +8,14 @@ function check_status(){
         -H "Authorization: Bearer ${GITHUB_ADMIN_TOKEN}" \
         -H "X-GitHub-Api-Version: ${GITHUB_API_VERSION}" \
         https://api.github.com/orgs/${ORG_NAME}/actions/runners)
-    echo "RESPONSE ${RESPONSE}"    
+ 
     RUNNERS=$(echo "${RESPONSE}" | jq -r '.runners')
     if [ "${RUNNERS}" = "null" ]; then
         echo "Problem with the token"
         exit 1
         return
     fi
-    echo "RUNNERS $RUNNERS"
+
     STATUS=$(echo "${RESPONSE}" | jq ".runners[] | select(.name == \"${RUNNER_NAME}\") | .status")
     STATUSES+=(${STATUS})
 }
@@ -23,7 +23,6 @@ function check_status(){
 runners=( ${RUNNER_NAMES} )
 for runner in "${runners[@]}"
 do
-echo "runner ${runner}"
 check_status "${runner}"
 done 
 

--- a/CheckStatus.sh
+++ b/CheckStatus.sh
@@ -8,14 +8,14 @@ function check_status(){
         -H "Authorization: Bearer ${GITHUB_ADMIN_TOKEN}" \
         -H "X-GitHub-Api-Version: ${GITHUB_API_VERSION}" \
         https://api.github.com/orgs/${ORG_NAME}/actions/runners)
-        
+    echo "RESPONSE ${RESPONSE}"    
     RUNNERS=$(echo "${RESPONSE}" | jq -r '.runners')
     if [ "${RUNNERS}" = "null" ]; then
         echo "Problem with the token"
         exit 1
         return
     fi
-    
+    echo "RUNNERS $RUNNERS"
     STATUS=$(echo "${RESPONSE}" | jq ".runners[] | select(.name == \"${RUNNER_NAME}\") | .status")
     STATUSES+=(${STATUS})
 }
@@ -23,6 +23,7 @@ function check_status(){
 runners=( ${RUNNER_NAMES} )
 for runner in "${runners[@]}"
 do
+echo "runner ${runner}"
 check_status "${runner}"
 done 
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ jobs:
         id: runnerstatus
         uses: SatelCreative/satel-gh-runner-check@1.0.0
         with:       
-          github-admin-token: ${{ secrets.ADMIN_TOKEN }} # Should have access to manage runner
+          github-admin-token: ${{ secrets.SELF_HOSTED_RUNNER_TOKEN }} #Fine grained token with access to self hosted runners only 
           org-name": <organization-name>
 ```
         

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ jobs:
         id: runnerstatus
         uses: SatelCreative/satel-gh-runner-check@1.0.0
         with:       
-          github-admin-token: ${{ secrets.SELF_HOSTED_RUNNER_TOKEN }} #Fine grained token with access to self hosted runners only 
+          github-runner-token: ${{ secrets.SELF_HOSTED_RUNNER_TOKEN }} #Fine grained token with access to self hosted runners only 
           org-name": <organization-name>
 ```
         

--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ runs:
       id: status-check
       env: 
         RUNNER_NAMES: 'cosmicray beast'
-        GITHUB_ADMIN_TOKEN: ${{ inputs.github-admin-token }}
+        GITHUB_RUNNER_TOKEN: ${{ inputs.github-runner-token }}
         GITHUB_API_VERSION: '2022-11-28'
         ORG_NAME: ${{ inputs.org-name}}
       run: ${{ github.action_path }}/CheckStatus.sh 

--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,7 @@ runs:
     - name: Check runner status
       id: status-check
       env: 
-        RUNNER_NAMES: 'cosmicray beast'
+        RUNNER_NAMES: 'beast'
         GITHUB_ADMIN_TOKEN: ${{ inputs.github-admin-token }}
         GITHUB_API_VERSION: '2022-11-28'
         ORG_NAME: ${{ inputs.org-name}}

--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,7 @@ runs:
     - name: Check runner status
       id: status-check
       env: 
-        RUNNER_NAMES: 'beast'
+        RUNNER_NAMES: 'cosmicray beast'
         GITHUB_ADMIN_TOKEN: ${{ inputs.github-admin-token }}
         GITHUB_API_VERSION: '2022-11-28'
         ORG_NAME: ${{ inputs.org-name}}

--- a/action.yml
+++ b/action.yml
@@ -2,8 +2,8 @@ name: Satel-github-runner-status
 description: Checks the status of a self-hosted runner
 
 inputs:
-  github-admin-token:
-    description: Token that can read runner data
+  github-runner-token:
+    description: Token that can read runner data of the organization
     required: true
   org-name: 
     description: Name of the organization


### PR DESCRIPTION
If the GitHub token was expired, we weren't catching the exit code, so this script was returning false even if the self-hosted runner was not down. This was causing a workflow in a repo to run on a github's runner. 

This PR will fail make the workflow fail if the token is expired. 